### PR TITLE
Change keybinding for other-window action

### DIFF
--- a/counsel-projectile.el
+++ b/counsel-projectile.el
@@ -62,7 +62,7 @@ With a prefix ARG invalidates the cache first."
 
 (ivy-set-actions
  'counsel-projectile-find-file
- '(("w" (lambda (x)
+ '(("f" (lambda (x)
           (with-ivy-window
             (find-file-other-window
              (projectile-expand-root x))))
@@ -92,7 +92,7 @@ With a prefix ARG invalidates the cache first."
 
 (ivy-set-actions
  'counsel-projectile-find-dir
- '(("w" (lambda (x)
+ '(("f" (lambda (x)
           (with-ivy-window
             (dired-other-window
              (projectile-expand-root x))))
@@ -116,7 +116,7 @@ With a prefix ARG invalidates the cache first."
 
 (ivy-set-actions
  'counsel-projectile-switch-to-buffer
- '(("w" (lambda (x)
+ '(("f" (lambda (x)
           (with-ivy-window
             (switch-to-buffer-other-window x)))
     "other window")))

--- a/counsel-projectile.el
+++ b/counsel-projectile.el
@@ -62,7 +62,7 @@ With a prefix ARG invalidates the cache first."
 
 (ivy-set-actions
  'counsel-projectile-find-file
- '(("f" (lambda (x)
+ '(("j" (lambda (x)
           (with-ivy-window
             (find-file-other-window
              (projectile-expand-root x))))
@@ -92,7 +92,7 @@ With a prefix ARG invalidates the cache first."
 
 (ivy-set-actions
  'counsel-projectile-find-dir
- '(("f" (lambda (x)
+ '(("j" (lambda (x)
           (with-ivy-window
             (dired-other-window
              (projectile-expand-root x))))
@@ -116,7 +116,7 @@ With a prefix ARG invalidates the cache first."
 
 (ivy-set-actions
  'counsel-projectile-switch-to-buffer
- '(("f" (lambda (x)
+ '(("j" (lambda (x)
           (with-ivy-window
             (switch-to-buffer-other-window x)))
     "other window")))


### PR DESCRIPTION
What do you think if key for opening stuff in other window will be same as in `counsel` for [find-file](https://github.com/abo-abo/swiper/blob/master/counsel.el#L1100)? 
In my workflow I often open files (buffers) in other window after I found them (I used `helm` before, but I like more `ivy`). So I think it will be more consistent if it will use same keybindings.
