### PR TITLE
Correct misspelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install the package from `MELPA` or `el-get`, or clone this repository somewhere
 
 # Usage
 
-The main function is `counsel-projectile`. It starts an `ivy-read` session with the list of `projectile` known projects as candidates. The current project, if any, comes first in this list. The default action switches to the selected project (therefore calling `projectile-switch-project-action`). There are several additional actions to swich project with a specific `projectile-switch-project-action` (eg `projectile-vc`). The action list can be customized since `ivy-read` is called with `:caller 'counsel-projectile`.
+The main function is `counsel-projectile`. It starts an `ivy-read` session with the list of `projectile` known projects as candidates. The current project, if any, comes first in this list. The default action switches to the selected project (therefore calling `projectile-switch-project-action`). There are several additional actions to switch project with a specific `projectile-switch-project-action` (eg `projectile-vc`). The action list can be customized since `ivy-read` is called with `:caller 'counsel-projectile`.
 
 In the action list, a new function `counsel-projectile-find-file` is used instead of the standard `projectile-find-file`. It simply proposes an additional action to find the file in another window (thus bringing together `projectile-find-file` and `projectile-find-file-other-window`). You may also call this function directly or bind it to some key. Similarly for two other new functions: `counsel-projectile-find-dir` and `counsel-projectile-switch-to-buffer`.
 


### PR DESCRIPTION
`to swich project` -> `to switch project`
