### PR TITLE
Autoload counsel-projectile-ag

### DIFF
--- a/counsel-projectile.el
+++ b/counsel-projectile.el
@@ -197,6 +197,7 @@ BUFFER may be a string or nil."
 
 ;;; counsel-projectile-ag
 
+;;;###autoload
 (defun counsel-projectile-ag (&optional options)
   "Ivy version of `projectile-ag'."
   (interactive)


### PR DESCRIPTION
I'm not sure if there was a reason this wasn't done already, but this
command not being autoloaded caused my keybinding to it to sometimes
error out (if it was the first counsel-projectile command that I used
in a given Emacs session).