### PR TITLE
Use `projectile-symbol-or-selection-at-point` as default for ag

### DIFF
--- a/counsel-projectile.el
+++ b/counsel-projectile.el
@@ -228,7 +228,7 @@ BUFFER may be a string or nil."
                                    (concat "--ignore " (shell-quote-argument i)))
                                  ignored
                                  " "))))
-        (counsel-ag nil
+        (counsel-ag (projectile-symbol-or-selection-at-point)
                     (projectile-project-root)
                     options
                     (projectile-prepend-project-name "ag")))


### PR DESCRIPTION
This enhances the user experience when performing a search using `counsel-projectile-ag` by providing a nice default search.