### PR TITLE
remove selected project instead of current project

### DIFF
--- a/counsel-projectile.el
+++ b/counsel-projectile.el
@@ -308,7 +308,7 @@ invokes `projectile-commander' instead of
     "kill all buffers")
    ("r" (lambda (dir)
           (let ((projectile-switch-project-action
-                 'projectile-remove-current-project-from-known-projects))
+                 (lambda () (projectile-remove-known-project dir))))
             (projectile-switch-project-by-name dir arg)))
     "remove from known projects")
    ("l" (lambda (dir)


### PR DESCRIPTION
`m-x counsel-projectile-switch-project` `m-o r` removes the *current* project
from `projectile-known-projects` instead of the selected one.

The expected behaviour is for the action to operate on the *selection*, which is
the case for the rest of the actions.

Note: I was not able to determine why this was happening. The use of dynamic binding
and my inexperience with the elisp debugger were a limitation; It looks like it
might be an inconsistency in the API, but not necessarily a bug in projectile.