### PR TITLE
Use `thing-at-point` as initial input for ag searches

### DIFF
--- a/counsel-projectile.el
+++ b/counsel-projectile.el
@@ -257,7 +257,7 @@ BUFFER may be a string or nil."
                                    (concat "--ignore-file " (shell-quote-argument i)))
                                  ignored
                                  " "))))
-        (counsel-rg nil
+        (counsel-rg (thing-at-point 'symbol t)
                     (projectile-project-root)
                     options
                     (projectile-prepend-project-name "rg")))

--- a/counsel-projectile.el
+++ b/counsel-projectile.el
@@ -228,7 +228,7 @@ BUFFER may be a string or nil."
                                    (concat "--ignore " (shell-quote-argument i)))
                                  ignored
                                  " "))))
-        (counsel-ag nil
+        (counsel-ag (thing-at-point 'symbol t)
                     (projectile-project-root)
                     options
                     (projectile-prepend-project-name "ag")))


### PR DESCRIPTION
Unlike the default Projectile UI, currently `counsel-projectile-ag` doesn't have a default input. This adds a default input using `thing-at-point`.