### PR TITLE
Fix the performance of counsel-projectile-switch-to-buffer

### DIFF
--- a/counsel-projectile.el
+++ b/counsel-projectile.el
@@ -162,9 +162,10 @@ With a prefix ARG invalidates the cache first."
 
 Like `projectile-project-buffer-names', but propertize buffer
 names as in `ivy--buffer-list'."
-  (ivy--buffer-list "" nil
-                    (lambda (x)
-                      (member (car x) (projectile-project-buffer-names)))))
+  (let ((buffer-names (projectile-project-buffer-names)))
+    (ivy--buffer-list "" nil
+                      (lambda (x)
+                        (member (car x) buffer-names)))))
 
 (defun counsel-projectile--switch-buffer-action (buffer &optional other-window)
   "Switch to BUFFER.


### PR DESCRIPTION
counsel-projectile-switch-to-buffer is quite slow comparing with projectile-switch-to-buffer due to the unnecessary evaluation of (projectile-project-buffer-names) in a loop.