### PR TITLE
fix rg ignore option in non git projects

### DIFF
--- a/counsel-projectile.el
+++ b/counsel-projectile.el
@@ -254,7 +254,7 @@ BUFFER may be a string or nil."
              (options
               (concat options " "
                       (mapconcat (lambda (i)
-                                   (concat "--ignore-file " (shell-quote-argument i)))
+                                   (concat "--glob " (shell-quote-argument (concat "!" i))))
                                  ignored
                                  " "))))
         (counsel-rg nil


### PR DESCRIPTION
- Fix #46
- according to rg's manual, files for `--ignore-file FILE ...` should
  be matched relative to the current working directory
- while `--glob` can accept files that does not exist in current
  project (Thanks to @chaoyi)