### PR TITLE
Add preselect for switch-to-buffer

### DIFF
--- a/counsel-projectile.el
+++ b/counsel-projectile.el
@@ -182,6 +182,7 @@ names as in `ivy--buffer-list'."
   (ivy-read (projectile-prepend-project-name "Switch to buffer: ")
             (counsel-projectile--buffer-list)
             :matcher #'ivy--switch-buffer-matcher
+            :preselect (buffer-name (other-buffer (current-buffer)))
             :require-match t
             :keymap counsel-projectile-map
             :action #'counsel-projectile-switch-to-buffer-action


### PR DESCRIPTION
Compared to `ivy-switch-buffer`,  `counsel-projectile-switch-to-buffer` does not pre-select the recent buffer.