### PR TITLE
Revert "Add preselect for switch-to-buffer"

### DIFF
--- a/counsel-projectile.el
+++ b/counsel-projectile.el
@@ -182,7 +182,6 @@ names as in `ivy--buffer-list'."
   (ivy-read (projectile-prepend-project-name "Switch to buffer: ")
             (counsel-projectile--buffer-list)
             :matcher #'ivy--switch-buffer-matcher
-            :preselect (buffer-name (other-buffer (current-buffer)))
             :require-match t
             :keymap counsel-projectile-map
             :action #'counsel-projectile-switch-to-buffer-action


### PR DESCRIPTION
Reverts ericdanan/counsel-projectile#53

I didn't look carefully enough, but the buffer returned by `other-buffer` may not belong to the current project, and prefer that we can know which buffer will be preselected without having to remember whether the most recently selected buffer was in the projedt or not. So it seems more natural to me to preselect the current buffer. I think this is what happens already because the current buffer is first in the list, but I could make it explicitly be preselected to be sure.

Thanks anyway.