### PR TITLE
Rename old variable in the remove-known-project action

### DIFF
--- a/counsel-projectile.el
+++ b/counsel-projectile.el
@@ -819,7 +819,7 @@ PROJECT buffers."
 PROJECT from the list of known projects."
   (projectile-remove-known-project project)
   (setq ivy--all-candidates
-        (delete dir ivy--all-candidates))
+        (delete project ivy--all-candidates))
   (ivy--reset-state ivy-last))
 
 (defun counsel-projectile-switch-project-action-edit-dir-locals (project)


### PR DESCRIPTION
When removing a project from my known project list, Emacs complains that `dir` is an unbound variable-- this should fix that.