### PR TITLE
Fix 'projectile-keymap-prefix' variable deprecation

### DIFF
--- a/counsel-projectile.el
+++ b/counsel-projectile.el
@@ -1373,8 +1373,10 @@ If not inside a project, call `counsel-projectile-switch-project'."
 (fset 'counsel-projectile-command-map counsel-projectile-command-map)
 
 (defvar counsel-projectile-mode-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map [remap projectile-command-map] 'counsel-projectile-command-map)
+  (let ((map (make-sparse-keymap))
+        (projectile-command-keymap (where-is-internal 'projectile-command-map nil t)))
+    (when projectile-command-keymap
+      (define-key map projectile-command-keymap 'counsel-projectile-command-map))
     (define-key map [remap projectile-find-file] 'counsel-projectile-find-file)
     (define-key map [remap projectile-find-dir] 'counsel-projectile-find-dir)
     (define-key map [remap projectile-switch-to-buffer] 'counsel-projectile-switch-to-buffer)

--- a/counsel-projectile.el
+++ b/counsel-projectile.el
@@ -1374,7 +1374,7 @@ If not inside a project, call `counsel-projectile-switch-project'."
 
 (defvar counsel-projectile-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map projectile-keymap-prefix 'counsel-projectile-command-map)
+    (define-key map [remap projectile-command-map] 'counsel-projectile-command-map)
     (define-key map [remap projectile-find-file] 'counsel-projectile-find-file)
     (define-key map [remap projectile-find-dir] 'counsel-projectile-find-dir)
     (define-key map [remap projectile-switch-to-buffer] 'counsel-projectile-switch-to-buffer)


### PR DESCRIPTION
Fix `projectile-keymap-prefix` variable deprecation. see https://github.com/bbatsov/projectile/commit/9c6e9813abec6e067c659e9107bf356086a95e04 
Get the binding from `projectile-command-map` instead. Fix #91, #93 
Documentation needs to be updated.