### PR TITLE
Fix "wrong-type-argument arrayp projectile-ripgrep"

### DIFF
--- a/counsel-projectile.el
+++ b/counsel-projectile.el
@@ -1461,14 +1461,14 @@ counterparts."
    (counsel-projectile-mode
     (projectile-mode)
     (dolist (binding counsel-projectile-key-bindings)
-      (if (functionp (car binding))
-          (define-key projectile-mode-map `[remap ,(car binding)] (cdr binding))
-        (define-key projectile-command-map (car binding) (cdr binding)))))
+      (if (sequencep (car binding))
+          (define-key projectile-command-map (car binding) (cdr binding))
+        (define-key projectile-mode-map `[remap ,(car binding)] (cdr binding)))))
    (t
     (dolist (binding counsel-projectile-key-bindings)
-      (if (functionp (car binding))
-          (define-key projectile-mode-map `[remap ,(car binding)] nil)
-        (define-key projectile-command-map (car binding) nil)))
+      (if (sequencep (car binding))
+          (define-key projectile-command-map (car binding) nil)
+        (define-key projectile-mode-map `[remap ,(car binding)] nil)))
     (projectile-mode -1))))
 
 ;;* provide


### PR DESCRIPTION
Ref #101 

Instead of checking if the first element of the binding is a function and if it isn't, assuming it to be a sequence, we do the opposite. This way, we don't have to depend on the function being already defined.