### PR TITLE
cp-grep: Fix missing spacing

### DIFF
--- a/counsel-projectile.el
+++ b/counsel-projectile.el
@@ -731,7 +731,7 @@ called with a prefix argument."
          (car (split-string counsel-projectile-grep-base-command)))
         (setq counsel-projectile-grep-command
               (format counsel-projectile-grep-base-command ignored path))
-        (ivy-read (projectile-prepend-project-name "grep")
+        (ivy-read (projectile-prepend-project-name "grep: ")
                   #'counsel-projectile-grep-function
                   :initial-input counsel-projectile-grep-initial-input
                   :dynamic-collection t


### PR DESCRIPTION
As the title says, the typed search text will directly follow "grep", which differs from previouse behaviour.