### PR TITLE
counsel-projectile-org-agenda: Use `expand-file-name` in predicate.

### DIFF
--- a/counsel-projectile.el
+++ b/counsel-projectile.el
@@ -1148,7 +1148,7 @@ Optional arguments ARG, KEYS, and RESTRICTION are as in
   (let* ((root (projectile-project-root))
          (org-agenda-files
           (cl-remove-if-not (lambda (file)
-                              (string-prefix-p root file))
+                              (string-prefix-p root (expand-file-name file)))
                             (org-agenda-files t 'ifmode))))
     (org-agenda arg keys restriction))))
 


### PR DESCRIPTION
I was confused when `counsel-projectile-org-agenda` didn't notice "~/project/notes.org", so this PR makes that an option.