### PR TITLE
fix: ivy occur requires a extra argument.

### DIFF
--- a/counsel-projectile.el
+++ b/counsel-projectile.el
@@ -678,7 +678,7 @@ construct the command.")
   ;; `counsel-ag'-like commands.
   (counsel-git-grep-transformer (string-remove-prefix "./" str)))
 
-(defun counsel-projectile-grep-occur ()
+(defun counsel-projectile-grep-occur (&optional _cands)
   "Generate a custom occur buffer for `counsel-projectile-grep'."
   (counsel-grep-like-occur
    counsel-projectile-grep-command))


### PR DESCRIPTION
Without the optional argument we will see this error:

    Debugger entered--Lisp error: (wrong-number-of-arguments ((t) nil "Generate a custom occur buffer for `counsel-projec..." (counsel-grep-like-occur counsel-projectile-grep-command)) 1)
      counsel-projectile-grep-occur((#(...
      funcall(counsel-projectile-grep-occur (#(...
      (save-current-buffer (set-buffer buffer) (funcall occur-fn ivy--old-cands) (progn (or (and (memq (type-of ivy-last) cl-struct-ivy-state-tags) t) (signal 'wrong-type-argument (list 'ivy-state ivy-last))) (let* ((v ivy-last)) (aset v 14 ivy-text))) (setq ivy-occur-last ivy-last))
      (let* ((caller (progn (or (and (memq (type-of ivy-last) cl-struct-ivy-state-tags) t) (signal 'wrong-type-argument (list 'ivy-state ivy-last))) (aref ivy-last 22))) (occur-fn (or (plist-get ivy--occurs-list caller) #'ivy--occur-default)) (buffer (generate-new-buffer (format "*ivy-occur%s \"%s\"*" (if caller (concat " " (prin1-to-string caller)) "") ivy-text)))) (save-current-buffer (set-buffer buffer) (funcall occur-fn ivy--old-cands) (progn (or (and (memq (type-of ivy-last) cl-struct-ivy-state-tags) t) (signal 'wrong-type-argument (list 'ivy-state ivy-last))) (let* ((v ivy-last)) (aset v 14 ivy-text))) (setq ivy-occur-last ivy-last)) (ivy-exit-with-action #'(lambda (_) (pop-to-buffer buffer) (setq next-error-last-buffer buffer) (set (make-local-variable 'next-error-function) #'ivy-occur-next-error))))
      (if (not (window-minibuffer-p)) (user-error "No completion session is active") (let* ((caller (progn (or (and (memq ... cl-struct-ivy-state-tags) t) (signal 'wrong-type-argument (list ... ivy-last))) (aref ivy-last 22))) (occur-fn (or (plist-get ivy--occurs-list caller) #'ivy--occur-default)) (buffer (generate-new-buffer (format "*ivy-occur%s \"%s\"*" (if caller (concat " " ...) "") ivy-text)))) (save-current-buffer (set-buffer buffer) (funcall occur-fn ivy--old-cands) (progn (or (and (memq (type-of ivy-last) cl-struct-ivy-state-tags) t) (signal 'wrong-type-argument (list 'ivy-state ivy-last))) (let* ((v ivy-last)) (aset v 14 ivy-text))) (setq ivy-occur-last ivy-last)) (ivy-exit-with-action #'(lambda (_) (pop-to-buffer buffer) (setq next-error-last-buffer buffer) (set (make-local-variable 'next-error-function) #'ivy-occur-next-error)))))
      ivy-occur()
      funcall-interactively(ivy-occur)
      call-interactively(ivy-occur nil nil)
      command-execute(ivy-occur)